### PR TITLE
GCC and BINUTILS update & Others

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,6 @@ Some common triples include:
  - x86_64-elf
  - arm-none-eabi
  - aarch64-none-elf
+ - riscv64-none-elf
  
 Read more about Target Triplets at [Target Triplets](https://wiki.osdev.org/Target_Triplet).

--- a/README.md
+++ b/README.md
@@ -5,13 +5,17 @@ Just place the cross-compiler.sh script in your home directory and launch it fro
 
     ./cross-compiler.sh x86_64-elf
 
-Replace x86_64-elf with your target and you are set. It will do everything. It will create all directories you need, download GCC 9.2.0 and Binutils 2.33 and build them together. It even installs the prerequisites for you. It only works on apt-based systems and has only been tested on Ubuntu.
+If you want to set a specific version of gcc or binutils, use the BINUTILS and GCC environment variables:
+
+    GCC=gcc-13.2.0 BINUTILS=binutils-2.42 ./cross-compiler.sh x86_64-elf
+
+Replace x86_64-elf with your target and you are set. It will do everything. It will create all directories you need, download GCC 11.4.0 and Binutils 2.38 and build them together. It even installs the prerequisites for you. It only works on apt-based systems and has only been tested on Ubuntu.
 
 You will also need to run something like the following command when you want to use the cross-compiler:
 
     . activate.sh
 
-Common target triples are x86_64-elf and i386-elf, others include:
+Some common triples include:
  - i686-elf
  - x86_64-elf
  - arm-none-eabi

--- a/cross-compiler.sh
+++ b/cross-compiler.sh
@@ -20,19 +20,20 @@ sudo apt install libgmp3-dev libmpfr-dev libisl-dev libmpc-dev texinfo -y
 
 cd "$(dirname "$0")"
 
-mkdir out
-cd out
+mkdir -pv out/{src,path}
+cd out/src
 
-mkdir path
-mkdir src
 
-cd src
+rm -rvf $BINUTILS.tar.xz $GCC.tar.xz
 
 wget https://ftp.gnu.org/gnu/binutils/$BINUTILS.tar.xz
 wget https://ftp.gnu.org/gnu/gcc/$GCC/$GCC.tar.xz
 
-tar -xvf $BINUTILS.tar.xz
-tar -xvf $GCC.tar.xz
+echo "Extracting Binutils..."
+tar -xf $BINUTILS.tar.xz
+
+echo "Extracting GCC..."
+tar -xf $GCC.tar.xz
 
 export PREFIX="$(pwd)/../path/"
 export TARGET=$1

--- a/cross-compiler.sh
+++ b/cross-compiler.sh
@@ -20,8 +20,8 @@ cd src
 wget https://ftp.gnu.org/gnu/binutils/binutils-2.33.1.tar.xz
 wget ftp://ftp.gnu.org/gnu/gcc/gcc-9.2.0/gcc-9.2.0.tar.xz
 
-tar -xvzf binutils-2.33.1.tar.xz
-tar -xvzf gcc-9.2.0.tar.xz
+tar -xvf binutils-2.33.1.tar.xz
+tar -xvf gcc-9.2.0.tar.xz
 
 export PREFIX="$(pwd)/../path/"
 export TARGET=$1

--- a/cross-compiler.sh
+++ b/cross-compiler.sh
@@ -5,7 +5,18 @@ if [ "$#" -ne 1 ]; then
   exit 1
 fi
 
-sudo apt install libgmp3-dev libmpfr-dev libisl-dev libcloog-isl-dev libmpc-dev texinfo -y
+if [ -z "${BINUTILS}" ]; then
+	BINUTILS="binutils-2.38"
+fi
+echo "Using ${BINUTILS}"
+
+if [ -z "${GCC}" ]; then
+	GCC="gcc-11.4.0"
+fi
+echo "Using ${GCC}"
+
+echo "Installing dependencies... (root might be needed)"
+sudo apt install libgmp3-dev libmpfr-dev libisl-dev libmpc-dev texinfo -y
 
 cd "$(dirname "$0")"
 
@@ -17,11 +28,11 @@ mkdir src
 
 cd src
 
-wget https://ftp.gnu.org/gnu/binutils/binutils-2.33.1.tar.xz
-wget ftp://ftp.gnu.org/gnu/gcc/gcc-9.2.0/gcc-9.2.0.tar.xz
+wget https://ftp.gnu.org/gnu/binutils/$BINUTILS.tar.xz
+wget https://ftp.gnu.org/gnu/gcc/$GCC/$GCC.tar.xz
 
-tar -xvf binutils-2.33.1.tar.xz
-tar -xvf gcc-9.2.0.tar.xz
+tar -xvf $BINUTILS.tar.xz
+tar -xvf $GCC.tar.xz
 
 export PREFIX="$(pwd)/../path/"
 export TARGET=$1
@@ -29,14 +40,14 @@ export PATH="$PREFIX/bin:$PATH"
 
 mkdir build-binutils
 cd build-binutils
-../binutils-2.33.1/configure --target=$TARGET --prefix="$PREFIX" --with-sysroot --disable-nls --disable-werror
+../$BINUTILS/configure --target=$TARGET --prefix="$PREFIX" --with-sysroot --disable-nls --disable-werror
 make -j $(nproc)
 make install
 
 cd ..
 mkdir build-gcc
 cd build-gcc
-../gcc-9.2.0/configure --target=$TARGET --prefix="$PREFIX" --disable-nls --enable-languages=c,c++ --without-headers
+../$GCC/configure --target=$TARGET --prefix="$PREFIX" --disable-nls --enable-languages=c,c++ --without-headers
 make -j $(nproc) all-gcc
 make -j $(nproc) all-target-libgcc
 make install-gcc


### PR DESCRIPTION
 - Updated BINUTILS to 2.38
 - Updated GCC to 11.4.0
 - Added environment variables to specify GCC and BINUTILS version ($GCC and $BINUTILS)
 - Fix #5 by removing the `-z` flag from tar commands as it specifies gzip and the downloads are xz
 - Refactored the commands that create the folder structure 
 - Remove the existing .tar.xz files automatically
 - Added RISC-V triple to README.md